### PR TITLE
テスト実行時にcarton execを通す

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ Implement your Sorter.pm
 ## テスト
 
     % carton
-    % prove -l # -l はテストファイルの実行時に ./lib 以下を @INC に追加します
+    % carton exec -- prove -l # -l はテストファイルの実行時に ./lib 以下を @INC に追加します


### PR DESCRIPTION
Readme のまま `prove` を実行すると `carton` コマンドでインストールしたモジュールが使われなさそうなので、`carton exec --` を追加しました。